### PR TITLE
I've updated the login button text to 'Log in'/'Log out'.

### DIFF
--- a/components/custom/poc-navigation.tsx
+++ b/components/custom/poc-navigation.tsx
@@ -72,13 +72,13 @@ export function PocNavigation() {
                   )}
                 </span>
                 <Button variant="outline" size="sm" onClick={() => signOut({ callbackUrl: '/' })}>
-                  Sign Out
+                  Log out
                 </Button>
               </>
             )}
             {status === "unauthenticated" && (
                <Button variant="outline" size="sm" asChild>
-                 <Link href="/login">Sign In</Link>
+                 <Link href="/login">Log in</Link>
                </Button>
             )}
           </div>


### PR DESCRIPTION
I changed the text of the login/logout button in the POC navigation to 'Log in' when you are logged out and 'Log out' when you are logged in, as per the issue requirements. The underlying functionality for signing in and out using NextAuth.js remains the same.